### PR TITLE
Correct the akka cluster port

### DIFF
--- a/GettingStarted-HelloWorld.md
+++ b/GettingStarted-HelloWorld.md
@@ -124,7 +124,7 @@ To start the platform, enter the following command:
 java -cp "coral-runtime-0.0.131.jar" \
     io.coral.api.Boot start \
 	-ai "0.0.0.0" -p 8000 -ah "127.0.0.1" \
-	-ap 2551 -am "coral" -ccp "192.168.100.101" \
+	-ap 2555 -am "coral" -ccp "192.168.100.101" \
 	-cp 9042 -k "coral" -nc -ll INFO
 {% endhighlight %}
 

--- a/GettingStarted-HelloWorldKafka.md
+++ b/GettingStarted-HelloWorldKafka.md
@@ -85,7 +85,7 @@ To start the platform, enter the following command:
 java -cp "coral-runtime-0.0.131.jar" \
     io.coral.api.Boot start \
     -ai "0.0.0.0" -p 8000 -ah "127.0.0.1" \
-    -ap 2551 -am "coral" -ccp "192.168.100.101" \
+    -ap 2555 -am "coral" -ccp "192.168.100.101" \
     -cp 9042 -k "coral" -nc -ll INFO
 {% endhighlight %}
 


### PR DESCRIPTION
The akka cluster port in the start command on the site(2551) is inconsistent with the value configured in the source code(2555).
